### PR TITLE
fix: 修正鸣谢信息错别字，西柚WIKI -> 西邮WIKI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## 鸣谢
 
-源仓库：[西柚WIKI](https://wiki.cooo.site/)
+源仓库：[西邮WIKI](https://wiki.cooo.site/)
 
 ## 本地运行/部署
 


### PR DESCRIPTION
Fixes #8

修正 README 中鸣谢部分的错别字：
- 西柚WIKI → 西邮WIKI（西安邮电大学WIKI）