### PR TITLE
fix: 将AI问答频率限制从60秒改为30秒

### DIFF
--- a/docs/.vitepress/components/AIChat.vue
+++ b/docs/.vitepress/components/AIChat.vue
@@ -390,9 +390,9 @@ const toggleChat = async () => {
   }
 }
 
-// 频率限制：每分钟最多1次
+// 频率限制：每30秒最多1次
 const RATE_LIMIT_KEY = 'ai_chat_last_request'
-const RATE_LIMIT_SECONDS = 60
+const RATE_LIMIT_SECONDS = 30
 const cooldownLeft = ref(0)
 let cooldownTimer: ReturnType<typeof setInterval> | null = null
 


### PR DESCRIPTION
将AI助手的问答频率限制从60秒缩短为30秒，提升用户体验。